### PR TITLE
Fix password comparison in require_password helper

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,7 +39,7 @@ APP_PASSWORD = "Xenomexpress7727"  # move to st.secrets if you prefer not to har
 
 def require_password():
     def on_password_entered():
-        if st.session_state["_password"] == Xenomexpress7727/:
+        if st.session_state["_password"] == APP_PASSWORD:
             st.session_state["auth_ok"] = True
             del st.session_state["_password"]
         else:


### PR DESCRIPTION
## Summary
- fix the `require_password` helper to compare the entered password against the `APP_PASSWORD` constant
- remove the stray characters that broke the password check so the prompt gates the rest of the UI

## Testing
- not run (streamlit server not started in CI)


------
https://chatgpt.com/codex/tasks/task_e_68cadb306f9c8321bfe3d3ec02f02a7b