### PR TITLE
Handle reference link visibility based on score

### DIFF
--- a/app.py
+++ b/app.py
@@ -580,6 +580,19 @@ def save_row(row: dict, to_sheet: bool = True, to_firestore: bool = False) -> di
         first failure returned.
     """
 
+    row = dict(row)
+
+    score_val = row.get("score")
+    try:
+        score_int = int(score_val)
+    except (TypeError, ValueError):
+        score_int = None
+
+    if score_int is not None:
+        row["score"] = score_int
+        if score_int < 60:
+            row["link"] = ""
+
     result: Dict[str, Any] = {"ok": True}
     messages: List[str] = []
 
@@ -779,15 +792,18 @@ if st.button("💾 Save", type="primary", use_container_width=True):
         except ValueError:
             studentcode_val = studentcode
 
+        score_int = int(score)
+        link_value = st.session_state.ref_link if score_int >= 60 else ""
+
         row = {
             "studentcode": studentcode_val,
             "name":        student_name,
             "assignment":  st.session_state.ref_assignment,
-            "score":       int(score),
+            "score":       score_int,
             "comments":    feedback.strip(),
             "date":        datetime.now().strftime("%Y-%m-%d"),
             "level":       student_level,
-            "link":        st.session_state.ref_link,  # uses answer_url only
+            "link":        link_value,  # uses answer_url only when allowed
         }
 
         result = save_row(row, to_firestore=save_to_firestore)

--- a/tests/test_save_row_to_scores.py
+++ b/tests/test_save_row_to_scores.py
@@ -6,6 +6,7 @@ import ast
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import requests
+from typing import Any, Dict, List
 
 
 def _load_save_row_to_scores():
@@ -21,6 +22,23 @@ def _load_save_row_to_scores():
     }
     exec(compile(module, "app.py", "exec"), namespace)
     return namespace["save_row_to_scores"]
+
+
+def _load_save_row():
+    path = os.path.join(os.path.dirname(__file__), "..", "app.py")
+    with open(path, "r", encoding="utf-8") as f:
+        tree = ast.parse(f.read(), filename="app.py")
+    func_node = next(node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name == "save_row")
+    module = ast.Module(body=[func_node], type_ignores=[])
+    namespace = {
+        "Dict": Dict,
+        "Any": Any,
+        "List": List,
+        "save_row_to_scores": lambda row: {"ok": True, "message": "Saved to Scores sheet"},
+        "save_row_to_firestore": lambda row: {"ok": True, "message": "Saved to Firestore"},
+    }
+    exec(compile(module, "app.py", "exec"), namespace)
+    return namespace["save_row"]
 
 
 def test_save_row_to_scores_non_2xx(monkeypatch):
@@ -49,3 +67,61 @@ def test_save_row_to_scores_success_default(monkeypatch):
 
     result = save_row_to_scores({"foo": "bar"})
     assert result == {"ok": True, "raw": "All good", "message": "Saved to Scores sheet"}
+
+
+def test_save_row_drops_reference_link_below_sixty():
+    save_row = _load_save_row()
+
+    sheet_rows = []
+    firestore_rows = []
+
+    def fake_scores(row):
+        sheet_rows.append(dict(row))
+        return {"ok": True, "message": "Saved to Scores sheet"}
+
+    def fake_firestore(row):
+        firestore_rows.append(dict(row))
+        return {"ok": True, "message": "Saved to Firestore"}
+
+    save_row.__globals__["save_row_to_scores"] = fake_scores
+    save_row.__globals__["save_row_to_firestore"] = fake_firestore
+
+    res = save_row(
+        {
+            "studentcode": "abc",
+            "score": 55,
+            "link": "https://example.com",
+        },
+        to_sheet=True,
+        to_firestore=True,
+    )
+
+    assert res["ok"]
+    assert sheet_rows[0]["link"] == ""
+    assert firestore_rows[0]["link"] == ""
+
+
+def test_save_row_keeps_reference_link_at_sixty_or_higher():
+    save_row = _load_save_row()
+
+    captured = {}
+
+    def fake_scores(row):
+        captured.setdefault("sheet", dict(row))
+        return {"ok": True, "message": "Saved to Scores sheet"}
+
+    save_row.__globals__["save_row_to_scores"] = fake_scores
+    save_row.__globals__["save_row_to_firestore"] = lambda row: {"ok": True, "message": "Saved to Firestore"}
+
+    res = save_row(
+        {
+            "studentcode": "abc",
+            "score": "60",
+            "link": "https://example.com",
+        },
+        to_sheet=True,
+        to_firestore=False,
+    )
+
+    assert res["ok"]
+    assert captured["sheet"]["link"] == "https://example.com"


### PR DESCRIPTION
## Summary
- ensure the UI saves an empty reference link when a score below 60 is recorded
- sanitize `save_row` payloads so both sheet and Firestore writes drop low-score links
- extend the save-row test suite to cover the link handling rules

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbe40909c48321bb03f9949f96031b