### PR TITLE
Fix commas in answers dictionary JSON

### DIFF
--- a/answers_dictionary.json
+++ b/answers_dictionary.json
@@ -873,11 +873,11 @@
         "Answer2": "d) Müsli oder Toast mit Marmelade",
         "Answer3": "b) Hausaufgaben",
         "Answer4": "a) am Nachmittag",
-        "Answer5": "b) Freunde treffen",
+        "Answer5": "b) Freunde treffen"
       },
       "teil4": {
         "Answer1": "c) die Schweiz",
-        "Answer2": "d) mit dem Zug"
+        "Answer2": "d) mit dem Zug",
         "Answer3": "a) an einem kleinen Bahnhof",
         "Answer4": "d) einen Zimmerschlüssel",
         "Answer5": "b) das Zimmer ist zu klein"


### PR DESCRIPTION
## Summary
- remove an invalid trailing comma from the `A2 9.25` `teil3` answers block
- add the missing comma after the `A2 9.25` `teil4` Answer2 entry so the JSON structure is valid

## Testing
- python -m json.tool answers_dictionary.json

------
https://chatgpt.com/codex/tasks/task_e_68cd5f96ab7083219af3b300280f7343