### PR TITLE
Fix Streamlit page config order

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,9 @@ import requests
 import streamlit as st
 import streamlit.components.v1 as components
 
+# Configure page immediately after importing Streamlit to avoid API exceptions.
+st.set_page_config(page_title="📘 Marking Dashboard", page_icon="📘", layout="wide")
+
 # ---------------- Firebase ----------------
 from firebase_utils import get_firestore_client, save_row_to_firestore
 
@@ -776,7 +779,6 @@ def save_row(row: dict, to_sheet: bool = True, to_firestore: bool = False) -> di
 # =========================================================
 # UI
 # =========================================================
-st.set_page_config(page_title="📘 Marking Dashboard", page_icon="📘", layout="wide")
 message = st.session_state.pop("last_save_success", None)
 if message:
     st.success("✅ " + message)


### PR DESCRIPTION
## Summary
- move the `st.set_page_config` call to the top of the app so it executes before other Streamlit API usage and avoids runtime errors

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d57c7281588321a6df4a4b5bb241f9