### PR TITLE
Fix JSON syntax in A2 2.4 answers

### DIFF
--- a/answers_dictionary.json
+++ b/answers_dictionary.json
@@ -452,7 +452,7 @@
       "teil4": {
         "Answer1": "B) Um 10 Uhr",
         "Answer2": "B) Eine Rucksack",
-        "Answer3": "B) Ein Piknik"
+        "Answer3": "B) Ein Piknik",
         "Answer4": "C) in einem Restaurant",
         "Answer3": "A) Spielen und Spazieren gehen"
       }


### PR DESCRIPTION
## Summary
- add the missing comma after the A2 2.4 teil4 Answer3 entry so Answer4 parses correctly

## Testing
- python -m json.tool answers_dictionary.json

------
https://chatgpt.com/codex/tasks/task_e_68d94397ff548321b781c9dd4c9b5001